### PR TITLE
Add keyword for Flickr safety level

### DIFF
--- a/admin/template/import.list_all.tpl
+++ b/admin/template/import.list_all.tpl
@@ -45,6 +45,7 @@ var flickrUserId = '{$flickrUserId}';
       <label><input type="checkbox" name="fill_description" checked="checked"> {'Description'|@translate}</label>
       <label><input type="checkbox" name="fill_geotag" checked="checked"> {'Geolocalization'|@translate}</label>
       <label><input type="checkbox" name="fill_level" checked="checked"> {'Privacy level'|@translate}</label>
+      <label><input type="checkbox" name="fill_safety" checked="checked"> {'Safety level (as keyword)'|@translate}</label>
     </p>
 
     <p>


### PR DESCRIPTION
This adds a 'Restricted' or 'Moderate' keyword for photos
marked as such on Flickr.

Refs: #17