### PR TITLE
import "post date" from flickr by default

### DIFF
--- a/admin/template/import.list_all.tpl
+++ b/admin/template/import.list_all.tpl
@@ -41,7 +41,7 @@ var flickrUserId = '{$flickrUserId}';
       <label><input type="checkbox" name="fill_author" checked="checked"> {'Author'|translate}</label>
       <label><input type="checkbox" name="fill_tags" checked="checked"> {'Tags'|translate}</label>
       <label><input type="checkbox" name="fill_taken" checked="checked"> {'Creation date'|translate}</label>
-      <label><input type="checkbox" name="fill_posted"> {'Post date'|translate}</label>
+      <label><input type="checkbox" name="fill_posted" checked="checked"> {'Post date'|translate}</label>
       <label><input type="checkbox" name="fill_description" checked="checked"> {'Description'|translate}</label>
       <label><input type="checkbox" name="fill_geotag" checked="checked"> {'Geolocalization'|translate}</label>
       <label><input type="checkbox" name="fill_level" checked="checked"> {'Privacy level'|translate}</label>

--- a/admin/template/import.list_photos.tpl
+++ b/admin/template/import.list_photos.tpl
@@ -392,7 +392,7 @@ jQuery('[data-add-album]').pwgAddAlbum({
       <label><input type="checkbox" name="fill_author" checked="checked"> {'Author'|translate}</label>
       <label><input type="checkbox" name="fill_tags" checked="checked"> {'Tags'|translate}</label>
       <label><input type="checkbox" name="fill_taken" checked="checked"> {'Creation date'|translate}</label>
-      <label><input type="checkbox" name="fill_posted"> {'Post date'|translate}</label>
+      <label><input type="checkbox" name="fill_posted" checked="checked"> {'Post date'|translate}</label>
       <label><input type="checkbox" name="fill_description" checked="checked"> {'Description'|translate}</label>
       <label><input type="checkbox" name="fill_geotag" checked="checked"> {'Geolocalization'|translate}</label>
       <label><input type="checkbox" name="fill_level" checked="checked"> {'Privacy level'|translate}</label>


### PR DESCRIPTION
when importing photos from flickr, by default all metadata import options are enabled except the "post date". In order to be more uniform and to make sure to import all metadata from flickr, this should IMHO be the case.