### PR TITLE
Fix line endings of some lang files

### DIFF
--- a/language/hu_HU/plugin.lang.php
+++ b/language/hu_HU/plugin.lang.php
@@ -1,1 +1,52 @@
-<?php// +-----------------------------------------------------------------------+// | Piwigo - a PHP based photo gallery                                    |// +-----------------------------------------------------------------------+// | Copyright(C) 2008-2012 Piwigo Team                  http://piwigo.org |// | Copyright(C) 2003-2008 PhpWebGallery Team    http://phpwebgallery.net |// | Copyright(C) 2002-2003 Pierrick LE GALL   http://le-gall.net/pierrick |// +-----------------------------------------------------------------------+// | This program is free software; you can redistribute it and/or modify  |// | it under the terms of the GNU General Public License as published by  |// | the Free Software Foundation                                          |// |                                                                       |// | This program is distributed in the hope that it will be useful, but   |// | WITHOUT ANY WARRANTY; without even the implied warranty of            |// | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU      |// | General Public License for more details.                              |// |                                                                       |// | You should have received a copy of the GNU General Public License     |// | along with this program; if not, write to the Free Software           |// | Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, |// | USA.                                                                  |// +-----------------------------------------------------------------------+$lang['One picture is not displayed because already existing in the database.'] = 'Egy kép nem látható, mert már létezik az adatbázisban.';$lang['Logged in as'] = 'Bejelentkzeve, mint';$lang['Logged out'] = 'Kijelentkezve';$lang['No download method available'] = 'Nincs használható letöltési módszer';$lang['Open Flickr page in a new tab'] = 'Flickr oldal megnyitása egy új fülben';$lang['Photo "%s" imported'] = '"%s" fotó importálva';$lang['Pictures without album'] = 'Album nélküli képek';$lang['Please fill your API keys on the configuration tab'] = 'Kérünk, add meg az API kulcsod a konfiguráció-fülön';$lang['Processing...'] = 'Feldolgozás folyamatban...';$lang['Reproduce flickr albums'] = 'Flickr albumok lemásolása';$lang['Successfully logged in to you Flickr account'] = 'Sikeresen bejelentkezve a Flickr fiókodba';$lang['Callback URL'] = 'Visszahívási URL';$lang['Fill these fields from Flickr datas'] = 'Ezeket a mezőket a Flickr adatokkal töltsd fel';$lang['Flickr logins'] = 'Flickr bejelentkezések';$lang['How do I get my Flickr API key?'] = 'Hogy kapom meg a Flickr API kulcsomat?';$lang['Import'] = 'Importálás';$lang['Import all my pictures'] = 'Az összes képem importálása';$lang['Import all photos in this album'] = 'Importáljuk az összes fotót ebből az albumból';$lang['Import options'] = 'Az importálás beállításai';$lang['List my albums'] = 'Az albumjaim listázása';$lang['List pictures of this album'] = 'Ezen album képeinek listázása';$lang['%d albums'] = '%d albumok';$lang['%d elements ready for importation'] = '%d tétel készen áll az importálásra';$lang['%d pictures are not displayed because already existing in the database.'] = '%d kép nem látható, mert már léteznek az adatbázisban.';$lang['%d pictures imported'] = '%d kép importálva';$lang['(%d photos)'] = '(%d fénykép)';$lang['API key'] = 'API kulcs';$lang['API not authenticated'] = 'API nincs hitelesítve';$lang['API secret'] = 'API titkos';$lang['Begin transfer'] = 'Átvitel indítása';?>
+<?php
+// +-----------------------------------------------------------------------+
+// | Piwigo - a PHP based photo gallery                                    |
+// +-----------------------------------------------------------------------+
+// | Copyright(C) 2008-2012 Piwigo Team                  http://piwigo.org |
+// | Copyright(C) 2003-2008 PhpWebGallery Team    http://phpwebgallery.net |
+// | Copyright(C) 2002-2003 Pierrick LE GALL   http://le-gall.net/pierrick |
+// +-----------------------------------------------------------------------+
+// | This program is free software; you can redistribute it and/or modify  |
+// | it under the terms of the GNU General Public License as published by  |
+// | the Free Software Foundation                                          |
+// |                                                                       |
+// | This program is distributed in the hope that it will be useful, but   |
+// | WITHOUT ANY WARRANTY; without even the implied warranty of            |
+// | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU      |
+// | General Public License for more details.                              |
+// |                                                                       |
+// | You should have received a copy of the GNU General Public License     |
+// | along with this program; if not, write to the Free Software           |
+// | Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, |
+// | USA.                                                                  |
+// +-----------------------------------------------------------------------+
+$lang['One picture is not displayed because already existing in the database.'] = 'Egy kép nem látható, mert már létezik az adatbázisban.';
+$lang['Logged in as'] = 'Bejelentkzeve, mint';
+$lang['Logged out'] = 'Kijelentkezve';
+$lang['No download method available'] = 'Nincs használható letöltési módszer';
+$lang['Open Flickr page in a new tab'] = 'Flickr oldal megnyitása egy új fülben';
+$lang['Photo "%s" imported'] = '"%s" fotó importálva';
+$lang['Pictures without album'] = 'Album nélküli képek';
+$lang['Please fill your API keys on the configuration tab'] = 'Kérünk, add meg az API kulcsod a konfiguráció-fülön';
+$lang['Processing...'] = 'Feldolgozás folyamatban...';
+$lang['Reproduce flickr albums'] = 'Flickr albumok lemásolása';
+$lang['Successfully logged in to you Flickr account'] = 'Sikeresen bejelentkezve a Flickr fiókodba';
+$lang['Callback URL'] = 'Visszahívási URL';
+$lang['Fill these fields from Flickr datas'] = 'Ezeket a mezőket a Flickr adatokkal töltsd fel';
+$lang['Flickr logins'] = 'Flickr bejelentkezések';
+$lang['How do I get my Flickr API key?'] = 'Hogy kapom meg a Flickr API kulcsomat?';
+$lang['Import'] = 'Importálás';
+$lang['Import all my pictures'] = 'Az összes képem importálása';
+$lang['Import all photos in this album'] = 'Importáljuk az összes fotót ebből az albumból';
+$lang['Import options'] = 'Az importálás beállításai';
+$lang['List my albums'] = 'Az albumjaim listázása';
+$lang['List pictures of this album'] = 'Ezen album képeinek listázása';
+$lang['%d albums'] = '%d albumok';
+$lang['%d elements ready for importation'] = '%d tétel készen áll az importálásra';
+$lang['%d pictures are not displayed because already existing in the database.'] = '%d kép nem látható, mert már léteznek az adatbázisban.';
+$lang['%d pictures imported'] = '%d kép importálva';
+$lang['(%d photos)'] = '(%d fénykép)';
+$lang['API key'] = 'API kulcs';
+$lang['API not authenticated'] = 'API nincs hitelesítve';
+$lang['API secret'] = 'API titkos';
+$lang['Begin transfer'] = 'Átvitel indítása';

--- a/language/sv_SE/plugin.lang.php
+++ b/language/sv_SE/plugin.lang.php
@@ -1,3 +1,25 @@
+<?php
+// +-----------------------------------------------------------------------+
+// | Piwigo - a PHP based photo gallery                                    |
+// +-----------------------------------------------------------------------+
+// | Copyright(C) 2008-2012 Piwigo Team                  http://piwigo.org |
+// | Copyright(C) 2003-2008 PhpWebGallery Team    http://phpwebgallery.net |
+// | Copyright(C) 2002-2003 Pierrick LE GALL   http://le-gall.net/pierrick |
+// +-----------------------------------------------------------------------+
+// | This program is free software; you can redistribute it and/or modify  |
+// | it under the terms of the GNU General Public License as published by  |
+// | the Free Software Foundation                                          |
+// |                                                                       |
+// | This program is distributed in the hope that it will be useful, but   |
+// | WITHOUT ANY WARRANTY; without even the implied warranty of            |
+// | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU      |
+// | General Public License for more details.                              |
+// |                                                                       |
+// | You should have received a copy of the GNU General Public License     |
+// | along with this program; if not, write to the Free Software           |
+// | Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, |
+// | USA.                                                                  |
+// +-----------------------------------------------------------------------+
 $lang['Callback URL'] = 'Återkopplings-URL';
 $lang['API not authenticated'] = 'API inte verifierat';
 $lang['Fill these fields from Flickr datas'] = 'Fyll dessa fält med Flickr-data';

--- a/language/th_TH/plugin.lang.php
+++ b/language/th_TH/plugin.lang.php
@@ -1,1 +1,28 @@
-<?php// +-----------------------------------------------------------------------+// | Piwigo - a PHP based photo gallery                                    |// +-----------------------------------------------------------------------+// | Copyright(C) 2008-2012 Piwigo Team                  http://piwigo.org |// | Copyright(C) 2003-2008 PhpWebGallery Team    http://phpwebgallery.net |// | Copyright(C) 2002-2003 Pierrick LE GALL   http://le-gall.net/pierrick |// +-----------------------------------------------------------------------+// | This program is free software; you can redistribute it and/or modify  |// | it under the terms of the GNU General Public License as published by  |// | the Free Software Foundation                                          |// |                                                                       |// | This program is distributed in the hope that it will be useful, but   |// | WITHOUT ANY WARRANTY; without even the implied warranty of            |// | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU      |// | General Public License for more details.                              |// |                                                                       |// | You should have received a copy of the GNU General Public License     |// | along with this program; if not, write to the Free Software           |// | Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, |// | USA.                                                                  |// +-----------------------------------------------------------------------+$lang['Import'] = 'นำเข้า';$lang['List my albums'] = 'รายชื่ออัลบั้มของฉัน';$lang['Import options'] = 'ตัวเลือกการนำเข้า';$lang['Logged in as'] = 'เข้าสู่ระบบโดย';$lang['API secret'] = 'API secret';$lang['API key'] = 'API key';?>
+<?php
+// +-----------------------------------------------------------------------+
+// | Piwigo - a PHP based photo gallery                                    |
+// +-----------------------------------------------------------------------+
+// | Copyright(C) 2008-2012 Piwigo Team                  http://piwigo.org |
+// | Copyright(C) 2003-2008 PhpWebGallery Team    http://phpwebgallery.net |
+// | Copyright(C) 2002-2003 Pierrick LE GALL   http://le-gall.net/pierrick |
+// +-----------------------------------------------------------------------+
+// | This program is free software; you can redistribute it and/or modify  |
+// | it under the terms of the GNU General Public License as published by  |
+// | the Free Software Foundation                                          |
+// |                                                                       |
+// | This program is distributed in the hope that it will be useful, but   |
+// | WITHOUT ANY WARRANTY; without even the implied warranty of            |
+// | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU      |
+// | General Public License for more details.                              |
+// |                                                                       |
+// | You should have received a copy of the GNU General Public License     |
+// | along with this program; if not, write to the Free Software           |
+// | Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, |
+// | USA.                                                                  |
+// +-----------------------------------------------------------------------+
+$lang['Import'] = 'นำเข้า';
+$lang['List my albums'] = 'รายชื่ออัลบั้มของฉัน';
+$lang['Import options'] = 'ตัวเลือกการนำเข้า';
+$lang['Logged in as'] = 'เข้าสู่ระบบโดย';
+$lang['API secret'] = 'API secret';
+$lang['API key'] = 'API key';


### PR DESCRIPTION
A few lang files had wrong line endings, and the transation tool
seems to have been failing on these. Notably, the PHP opening
tag was missing from sv_SE.