### PR TITLE
Flickr2Piwigo: add import of views counter

### DIFF
--- a/admin/template/import.list_all.tpl
+++ b/admin/template/import.list_all.tpl
@@ -44,6 +44,7 @@ var flickrUserId = '{$flickrUserId}';
       <label><input type="checkbox" name="fill_posted"> {'Post date'|translate}</label>
       <label><input type="checkbox" name="fill_description" checked="checked"> {'Description'|translate}</label>
       <label><input type="checkbox" name="fill_geotag" checked="checked"> {'Geolocalization'|translate}</label>
+      <label><input type="checkbox" name="fill_views" checked="checked"> {'View counter'|translate}</label>
       <label><input type="checkbox" name="fill_level" checked="checked"> {'Privacy level'|translate}</label>
       <label><input type="checkbox" name="fill_safety" checked="checked"> {'Safety level (as keyword)'|translate}</label>
     </p>

--- a/admin/template/import.list_photos.tpl
+++ b/admin/template/import.list_photos.tpl
@@ -395,6 +395,7 @@ jQuery('[data-add-album]').pwgAddAlbum({
       <label><input type="checkbox" name="fill_posted"> {'Post date'|translate}</label>
       <label><input type="checkbox" name="fill_description" checked="checked"> {'Description'|translate}</label>
       <label><input type="checkbox" name="fill_geotag" checked="checked"> {'Geolocalization'|translate}</label>
+      <label><input type="checkbox" name="fill_views" checked="checked"> {'View counter'|translate}</label>
       <label><input type="checkbox" name="fill_level" checked="checked"> {'Privacy level'|translate}</label>
     </p>
 

--- a/include/ws_functions.inc.php
+++ b/include/ws_functions.inc.php
@@ -202,6 +202,10 @@ function ws_flickr2piwigo_importPhoto($params)
       if ($photo['visibility']['isfamily']) $updates['level'] = 4;
       if ($photo['visibility']['isfriend']) $updates['level'] = 2;
     }
+    if (in_array('fill_views', $photo['fills']) && isset($photo['views'])) {
+      $logger->debug('Setting views counter to: '.$photo['views'], FLICKR2PIWIGO);
+      $updates['hit'] = (int)$photo['views'];
+    }
     if (count($updates))
     {
       $logger->debug('Updating metadata of Piwigo ID: '.$photo['image_id'], FLICKR2PIWIGO);

--- a/language/de_DE/plugin.lang.php
+++ b/language/de_DE/plugin.lang.php
@@ -70,3 +70,4 @@ $lang['month'] = 'Monat';
 $lang['year'] = 'Jahr';
 $lang['Create a new album'] = 'Neues Album erstellen';
 $lang['Unable to write to Flickr2Piwigo cache directory: %s'] = 'Flickr2Piwigo Zwischenspeicher-Verzeichnis kann nicht beschrieben werden: %s';
+$lang['View counter'] = 'Anzahl der Aufrufe';

--- a/language/en_UK/plugin.lang.php
+++ b/language/en_UK/plugin.lang.php
@@ -50,3 +50,4 @@ $lang['Unable to get info from Flickr about photo: %s'] = 'Unable to get info fr
 $lang['Unable to create category: %s'] = 'Unable to create category: %s';
 $lang['Unable to write to Flickr2Piwigo cache directory: %s'] = 'Unable to write to Flickr2Piwigo cache directory: %s';
 $lang['year'] = 'year';
+$lang['View counter'] = 'View counter';

--- a/language/fr_FR/plugin.lang.php
+++ b/language/fr_FR/plugin.lang.php
@@ -51,3 +51,4 @@ $lang['Help'] = 'Aide';
 $lang['Create a new album'] = 'Créer un nouvel album';
 $lang['Already imported: %s (Piwigo ID: %s)'] = 'Déjà importé : %s (Piwigo ID: %s)';
 $lang['Can\'t download file: %s'] = 'Échec du téléchargement du fichier : %s';
+$lang['View counter'] = 'Compteur d\'affichages';


### PR DESCRIPTION
Import a photo's view count along other metadata when importing from
flickr. Add a checkbox (activated by default) to let user chose the
desired behaviour.